### PR TITLE
Fix instantiating system context

### DIFF
--- a/index.php
+++ b/index.php
@@ -23,7 +23,7 @@
 require_once(__DIR__ . '/../../config.php');
 
 require_login();
-if (!has_capability('report/ldapaccounts:view', context::instance_by_id(CONTEXT_SYSTEM, MUST_EXIST))) {
+if (!has_capability('report/ldapaccounts:view', context_system::instance())) {
     throw new \moodle_exception('nopermissiontoaccesspage', 'error');
 }
 


### PR DESCRIPTION
The system context is instantiated with the constant `CONTEXT_SYSTEM` which is the context level not the context ID. This checks the wrong context and will fail if there is no context with ID 10.